### PR TITLE
bg header validation

### DIFF
--- a/middleware/request-validators/admin-reg-validator.js
+++ b/middleware/request-validators/admin-reg-validator.js
@@ -1,13 +1,14 @@
 const { body, header } = require('express-validator');
+const { mongoose: { Types } } = require('../../configs/mongodb-config');
 
 const validators = [
   header('useraccesspayload')
     .notEmpty()
-    .withMessage('User must be authorized'),
-  header('useraccesspayload.authId')
-    .isMongoId()
-    .trim(' ')
-    .notEmpty()
+    .withMessage('Not authorized')
+    .custom((val) => (
+      Types.ObjectId(val.authId)
+      && Types.ObjectId(val.authId).toHexString() === val.authId
+    ))
     .withMessage('Invalid access'),
   body('email')
     .trim(' ')

--- a/middleware/request-validators/ngo-post-event-validator.js
+++ b/middleware/request-validators/ngo-post-event-validator.js
@@ -1,13 +1,14 @@
 const { body, header } = require('express-validator');
+const { mongoose: { Types } } = require('../../configs/mongodb-config');
 
 const validators = [
   header('useraccesspayload')
     .notEmpty()
-    .withMessage('User must be authorized'),
-  header('useraccesspayload.authId')
-    .isMongoId()
-    .trim(' ')
-    .notEmpty()
+    .withMessage('Not authorized')
+    .custom((val) => (
+      Types.ObjectId(val.authId)
+      && Types.ObjectId(val.authId).toHexString() === val.authId
+    ))
     .withMessage('Invalid access'),
   body('name')
     .isString()


### PR DESCRIPTION
- ft(allocate-donation):feature skeleton[#28]
- ft(allocate-donation):updates feature skeleton[#28]
- ft(allocate-donation):runs tests[#28]
- ft(allocate-donation):auth password select default[#28]
- ft(allocate-donation):[Finishes #28]
- ft(allocate-donation):[Finishes #28]
- ft(allocate-donation):adds necessary response filters[Finishes #28]
- ft(allocate-donation):refactors authId header mongoId validation[#28]

## Tasks
- discards express-validator header validation for useraccesspayload.authId
- uses mongoose Types mongoId to equvilently cast and validate useraccesspayload.authId in express-validator